### PR TITLE
Error struct replaced with interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.0] - 2019-03-15
+
+### Added
+
+- `tracerr.CustomError()` that allows to create error with custom stack trace.
+
+### Changed
+
+- `*tracerr.Error` struct replaced with `tracerr.Error` interface.
+
 ## [0.2.1] - 2019-02-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ err = tracerr.Wrap(err)
 
 ### Print Error and Stack Trace
 
-> Stack trace will be printed only if `err` is of type `*tracerr.Error`, otherwise just error text will be shown.
+> Stack trace will be printed only if `err` is of type `tracerr.Error`, otherwise just error text will be shown.
 
 This will print error message and stack trace if any:
 
@@ -131,13 +131,13 @@ text := tracerr.SprintSource(err, 5, 2)
 
 ### Get Stack Trace
 
-> Stack trace will be empty if `err` is not an instance of `*tracerr.Error`.
+> Stack trace will be empty if `err` is not an instance of `tracerr.Error`.
 
 ```go
 frames := tracerr.StackTrace(err)
 ```
 
-Or if `err` is of type `*tracerr.Error`:
+Or if `err` is of type `tracerr.Error`:
 
 ```go
 frames := err.StackTrace()
@@ -145,13 +145,13 @@ frames := err.StackTrace()
 
 ### Get Original Error
 
-> Unwrapped error will be `nil` if `err` is `nil` and will be the same error if `err` is not an instance of `*tracerr.Error`.
+> Unwrapped error will be `nil` if `err` is `nil` and will be the same error if `err` is not an instance of `tracerr.Error`.
 
 ```go
 err = tracerr.Unwrap(err)
 ```
 
-Or if `err` is of type `*tracerr.Error`:
+Or if `err` is of type `tracerr.Error`:
 
 ```go
 err = err.Unwrap()

--- a/error_bench_test.go
+++ b/error_bench_test.go
@@ -26,7 +26,7 @@ func BenchmarkNew(b *testing.B) {
 	}
 }
 
-func addFrames(depth int, message string) *tracerr.Error {
+func addFrames(depth int, message string) error {
 	if depth <= 1 {
 		return tracerr.New(message)
 	}

--- a/error_helper_test.go
+++ b/error_helper_test.go
@@ -5,14 +5,14 @@ import (
 	"github.com/ztrue/tracerr"
 )
 
-func addFrameA(message string) *tracerr.Error {
+func addFrameA(message string) error {
 	return addFrameB(message)
 }
 
-func addFrameB(message string) *tracerr.Error {
+func addFrameB(message string) error {
 	return addFrameC(message)
 }
 
-func addFrameC(message string) *tracerr.Error {
+func addFrameC(message string) error {
 	return tracerr.New(message)
 }

--- a/examples/nil_error.go
+++ b/examples/nil_error.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/ztrue/tracerr"
+)
+
+func main() {
+	if err := nilError(); err != nil {
+		tracerr.PrintSourceColor(err)
+	} else {
+		fmt.Println("no error")
+	}
+}
+
+func nilError() error {
+	return tracerr.Wrap(nil)
+}

--- a/print.go
+++ b/print.go
@@ -154,7 +154,7 @@ func sprint(err error, nums []int, colorized bool) string {
 	if err == nil {
 		return ""
 	}
-	e, ok := err.(*Error)
+	e, ok := err.(Error)
 	if !ok {
 		return err.Error()
 	}

--- a/print_test.go
+++ b/print_test.go
@@ -71,7 +71,7 @@ func TestPrint(t *testing.T) {
 				"/src/github.com/ztrue/tracerr/error_helper_test.go:17 github.com/ztrue/tracerr_test.addFrameC()",
 				"14\t}",
 				"15\t",
-				"16\tfunc addFrameC(message string) *tracerr.Error {",
+				"16\tfunc addFrameC(message string) error {",
 				"17\t\treturn tracerr.New(message)",
 				"18\t}",
 				"19\t",
@@ -79,7 +79,7 @@ func TestPrint(t *testing.T) {
 				"/src/github.com/ztrue/tracerr/error_helper_test.go:13 github.com/ztrue/tracerr_test.addFrameB()",
 				"10\t}",
 				"11\t",
-				"12\tfunc addFrameB(message string) *tracerr.Error {",
+				"12\tfunc addFrameB(message string) error {",
 				"13\t\treturn addFrameC(message)",
 				"14\t}",
 				"15\t",
@@ -87,7 +87,7 @@ func TestPrint(t *testing.T) {
 				"/src/github.com/ztrue/tracerr/error_helper_test.go:9 github.com/ztrue/tracerr_test.addFrameA()",
 				"6\t)",
 				"7\t",
-				"8\tfunc addFrameA(message string) *tracerr.Error {",
+				"8\tfunc addFrameA(message string) error {",
 				"9\t\treturn addFrameB(message)",
 				"10\t}",
 				"11\t",
@@ -113,19 +113,19 @@ func TestPrint(t *testing.T) {
 				"",
 				"/src/github.com/ztrue/tracerr/error_helper_test.go:17 github.com/ztrue/tracerr_test.addFrameC()",
 				"15\t",
-				"16\tfunc addFrameC(message string) *tracerr.Error {",
+				"16\tfunc addFrameC(message string) error {",
 				"17\t\treturn tracerr.New(message)",
 				"18\t}",
 				"",
 				"/src/github.com/ztrue/tracerr/error_helper_test.go:13 github.com/ztrue/tracerr_test.addFrameB()",
 				"11\t",
-				"12\tfunc addFrameB(message string) *tracerr.Error {",
+				"12\tfunc addFrameB(message string) error {",
 				"13\t\treturn addFrameC(message)",
 				"14\t}",
 				"",
 				"/src/github.com/ztrue/tracerr/error_helper_test.go:9 github.com/ztrue/tracerr_test.addFrameA()",
 				"7\t",
-				"8\tfunc addFrameA(message string) *tracerr.Error {",
+				"8\tfunc addFrameA(message string) error {",
 				"9\t\treturn addFrameB(message)",
 				"10\t}",
 				"",
@@ -148,19 +148,19 @@ func TestPrint(t *testing.T) {
 				"",
 				"/src/github.com/ztrue/tracerr/error_helper_test.go:17 github.com/ztrue/tracerr_test.addFrameC()",
 				"15\t",
-				"16\tfunc addFrameC(message string) *tracerr.Error {",
+				"16\tfunc addFrameC(message string) error {",
 				"17\t\treturn tracerr.New(message)",
 				"18\t}",
 				"",
 				"/src/github.com/ztrue/tracerr/error_helper_test.go:13 github.com/ztrue/tracerr_test.addFrameB()",
 				"11\t",
-				"12\tfunc addFrameB(message string) *tracerr.Error {",
+				"12\tfunc addFrameB(message string) error {",
 				"13\t\treturn addFrameC(message)",
 				"14\t}",
 				"",
 				"/src/github.com/ztrue/tracerr/error_helper_test.go:9 github.com/ztrue/tracerr_test.addFrameA()",
 				"7\t",
-				"8\tfunc addFrameA(message string) *tracerr.Error {",
+				"8\tfunc addFrameA(message string) error {",
 				"9\t\treturn addFrameB(message)",
 				"10\t}",
 				"",
@@ -213,14 +213,14 @@ func TestPrint(t *testing.T) {
 				"13\t\treturn addFrameC(message)",
 				"14\t}",
 				"15\t",
-				"16\tfunc addFrameC(message string) *tracerr.Error {",
+				"16\tfunc addFrameC(message string) error {",
 				"17\t\treturn tracerr.New(message)",
 				"",
 				"/src/github.com/ztrue/tracerr/error_helper_test.go:9 github.com/ztrue/tracerr_test.addFrameA()",
 				"9\t\treturn addFrameB(message)",
 				"10\t}",
 				"11\t",
-				"12\tfunc addFrameB(message string) *tracerr.Error {",
+				"12\tfunc addFrameB(message string) error {",
 				"13\t\treturn addFrameC(message)",
 				"",
 				"/src/github.com/ztrue/tracerr/print_test.go:26 github.com/ztrue/tracerr_test.TestPrint()",
@@ -241,17 +241,17 @@ func TestPrint(t *testing.T) {
 				message,
 				"",
 				aurora.Bold("/src/github.com/ztrue/tracerr/error_helper_test.go:17 github.com/ztrue/tracerr_test.addFrameC()").String(),
-				aurora.Black("16").String() + "\tfunc addFrameC(message string) *tracerr.Error {",
+				aurora.Black("16").String() + "\tfunc addFrameC(message string) error {",
 				aurora.Red("17\t\treturn tracerr.New(message)").String(),
 				aurora.Black("18").String() + "\t}",
 				"",
 				aurora.Bold("/src/github.com/ztrue/tracerr/error_helper_test.go:13 github.com/ztrue/tracerr_test.addFrameB()").String(),
-				aurora.Black("12").String() + "\tfunc addFrameB(message string) *tracerr.Error {",
+				aurora.Black("12").String() + "\tfunc addFrameB(message string) error {",
 				aurora.Red("13\t\treturn addFrameC(message)").String(),
 				aurora.Black("14").String() + "\t}",
 				"",
 				aurora.Bold("/src/github.com/ztrue/tracerr/error_helper_test.go:9 github.com/ztrue/tracerr_test.addFrameA()").String(),
-				aurora.Black("8").String() + "\tfunc addFrameA(message string) *tracerr.Error {",
+				aurora.Black("8").String() + "\tfunc addFrameA(message string) error {",
 				aurora.Red("9\t\treturn addFrameB(message)").String(),
 				aurora.Black("10").String() + "\t}",
 				"",
@@ -273,9 +273,9 @@ func TestPrint(t *testing.T) {
 }
 
 func TestNoLine(t *testing.T) {
-	err := &tracerr.Error{
-		Err: errors.New("some error"),
-		Frames: []tracerr.Frame{
+	err := tracerr.CustomError(
+		errors.New("some error"),
+		[]tracerr.Frame{
 			{
 				Func: "main.Foo",
 				Line: 1337,
@@ -287,7 +287,7 @@ func TestNoLine(t *testing.T) {
 				Path: "error_helper_test.go",
 			},
 		},
-	}
+	)
 	output := tracerr.SprintSource(err)
 	expectedRows := []string{
 		"some error",
@@ -309,9 +309,9 @@ func TestNoLine(t *testing.T) {
 }
 
 func TestNoLineColor(t *testing.T) {
-	err := &tracerr.Error{
-		Err: errors.New("some error"),
-		Frames: []tracerr.Frame{
+	err := tracerr.CustomError(
+		errors.New("some error"),
+		[]tracerr.Frame{
 			{
 				Func: "main.Foo",
 				Line: 1337,
@@ -323,7 +323,7 @@ func TestNoLineColor(t *testing.T) {
 				Path: "error_helper_test.go",
 			},
 		},
-	}
+	)
 	output := tracerr.SprintSourceColor(err)
 	expectedRows := []string{
 		"some error",
@@ -345,9 +345,9 @@ func TestNoLineColor(t *testing.T) {
 }
 
 func TestNoSourceFile(t *testing.T) {
-	err := &tracerr.Error{
-		Err: errors.New("some error"),
-		Frames: []tracerr.Frame{
+	err := tracerr.CustomError(
+		errors.New("some error"),
+		[]tracerr.Frame{
 			{
 				Func: "main.Foo",
 				Line: 42,
@@ -359,7 +359,7 @@ func TestNoSourceFile(t *testing.T) {
 				Path: "/tmp/not_exists_2.go",
 			},
 		},
-	}
+	)
 	output := tracerr.SprintSource(err)
 	expectedRows := []string{
 		"some error",
@@ -381,9 +381,9 @@ func TestNoSourceFile(t *testing.T) {
 }
 
 func TestNoSourceFileColor(t *testing.T) {
-	err := &tracerr.Error{
-		Err: errors.New("some error"),
-		Frames: []tracerr.Frame{
+	err := tracerr.CustomError(
+		errors.New("some error"),
+		[]tracerr.Frame{
 			{
 				Func: "main.Foo",
 				Line: 42,
@@ -395,7 +395,7 @@ func TestNoSourceFileColor(t *testing.T) {
 				Path: "/tmp/not_exists_2.go",
 			},
 		},
-	}
+	)
 	output := tracerr.SprintSourceColor(err)
 	expectedRows := []string{
 		"some error",


### PR DESCRIPTION
This is necessary in order to fix conversion of `*tracerr.Error` to `error`, which produces non-nil interface even with nil value.